### PR TITLE
Add Swagger support to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # moment-sharing
+
+This repository contains the backend and frontend modules for the Moment Sharing application.
+
+## Swagger
+
+After starting the backend (`mvn spring-boot:run` in the `backend` directory), the API documentation is available at:
+
+- `http://localhost:8080/v3/api-docs`
+- `http://localhost:8080/swagger-ui.html`
+
+The Storage API supports operations using only the file's URL:
+
+- `GET /api/storage/download?url={fileUrl}` – download a file
+- `POST /api/storage/upload?url={fileUrl}` – upload a file from the given URL
+- `DELETE /api/storage/delete?url={fileUrl}` – delete the file at that URL

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/example/datalake/backend/controller/StorageController.java
+++ b/backend/src/main/java/com/example/datalake/backend/controller/StorageController.java
@@ -1,0 +1,47 @@
+package com.example.datalake.backend.controller;
+
+import com.example.datalake.backend.service.StorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Storage", description = "Supabase Storage operations")
+@RestController
+@RequestMapping("/api/storage")
+public class StorageController {
+    private final StorageService storageService;
+
+    public StorageController(StorageService storageService) {
+        this.storageService = storageService;
+    }
+
+    @Operation(summary = "List all buckets", description = "Returns all available Supabase buckets")
+    @GetMapping("/buckets")
+    public Mono<String> listBuckets() {
+        return storageService.listBuckets();
+    }
+
+    @Operation(summary = "Download file by URL", description = "Fetches a file from Supabase Storage using its URL")
+    @GetMapping("/download")
+    public Mono<?> download(@RequestParam String url) {
+        return storageService.downloadFileByUrl(url);
+    }
+
+    @Operation(summary = "Upload file by URL", description = "Uploads a file to Supabase Storage given its URL")
+    @PostMapping("/upload")
+    public Mono<String> upload(@RequestParam String url) {
+        return storageService.uploadFileByUrl(url);
+    }
+
+    @Operation(summary = "Delete file by URL", description = "Deletes a file from Supabase Storage given its URL")
+    @DeleteMapping("/delete")
+    public Mono<String> delete(@RequestParam String url) {
+        return storageService.deleteObjectByUrl(url);
+    }
+}


### PR DESCRIPTION
## Summary
- add Springdoc Swagger UI dependency
- document access to Swagger UI in README
- create `StorageController` with OpenAPI annotations
- provide upload, download and delete endpoints accepting only a file URL

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: command not found)*
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547d393ae08325b6802f146e132f13