### PR TITLE
Add Swagger support and sample controller

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/example/datalake/backend/controller/SampleController.java
+++ b/backend/src/main/java/com/example/datalake/backend/controller/SampleController.java
@@ -1,0 +1,13 @@
+package com.example.datalake.backend.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SampleController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello World";
+    }
+}


### PR DESCRIPTION
## Summary
- add Springdoc Swagger UI dependency
- create a simple `/hello` endpoint

## Testing
- `mvn -q -pl backend test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685495b3805c8325a0daa0a78020c45e