### PR TITLE
Add scheduled cleanup for expired records

### DIFF
--- a/backend/src/main/java/com/example/datalake/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/datalake/backend/BackendApplication.java
@@ -1,11 +1,13 @@
 package com.example.datalake.backend;
 
 import com.google.cloud.spring.data.firestore.repository.config.EnableReactiveFirestoreRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @EnableReactiveFirestoreRepositories
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/example/datalake/backend/controller/RecordController.java
+++ b/backend/src/main/java/com/example/datalake/backend/controller/RecordController.java
@@ -36,6 +36,14 @@ public class RecordController {
         return service.findAll();
     }
 
+    @Operation(summary = "List records by owner")
+    @GetMapping("/owner/{owner}")
+    public Flux<Record> byOwner(
+            @Parameter(description = "Owner username")
+            @PathVariable String owner) {
+        return service.findByOwner(owner);
+    }
+
     @Operation(summary = "Find a record by ID")
     @ApiResponse(responseCode = "200", description = "Found",
             content = @Content(schema = @Schema(implementation = Record.class)))

--- a/backend/src/main/java/com/example/datalake/backend/dao/SpringDataRecordRepository.java
+++ b/backend/src/main/java/com/example/datalake/backend/dao/SpringDataRecordRepository.java
@@ -17,4 +17,12 @@ public interface SpringDataRecordRepository extends FirestoreReactiveRepository<
      * @return flux of matching records
      */
     reactor.core.publisher.Flux<Record> findByCreatedAtLessThan(com.google.cloud.Timestamp timestamp);
+
+    /**
+     * Find all records owned by the given username.
+     *
+     * @param owner record owner
+     * @return flux of matching records
+     */
+    reactor.core.publisher.Flux<Record> findByOwner(String owner);
 }

--- a/backend/src/main/java/com/example/datalake/backend/dao/SpringDataRecordRepository.java
+++ b/backend/src/main/java/com/example/datalake/backend/dao/SpringDataRecordRepository.java
@@ -9,4 +9,12 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface SpringDataRecordRepository extends FirestoreReactiveRepository<Record> {
+
+    /**
+     * Find all records created before the given timestamp.
+     *
+     * @param timestamp cutoff timestamp
+     * @return flux of matching records
+     */
+    reactor.core.publisher.Flux<Record> findByCreatedAtLessThan(com.google.cloud.Timestamp timestamp);
 }

--- a/backend/src/main/java/com/example/datalake/backend/service/RecordCleanupScheduler.java
+++ b/backend/src/main/java/com/example/datalake/backend/service/RecordCleanupScheduler.java
@@ -1,0 +1,51 @@
+package com.example.datalake.backend.service;
+
+import com.example.datalake.backend.dao.SpringDataRecordRepository;
+import com.example.datalake.backend.model.Record;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RecordCleanupScheduler {
+
+    private final SpringDataRecordRepository repo;
+    private final StorageService storageService;
+
+    private static final Duration TTL = Duration.ofHours(24);
+
+    @Scheduled(fixedDelayString = "${record.cleanup.interval:3600000}")
+    public void removeExpiredRecords() {
+        Instant cutoff = Instant.now().minus(TTL);
+        repo.findAll()
+                .filter(record -> isExpired(record, cutoff))
+                .flatMap(this::deleteRecord)
+                .subscribe(
+                        r -> log.info("Removed expired record {}", r.getId()),
+                        ex -> log.error("Error during record cleanup", ex)
+                );
+    }
+
+    private boolean isExpired(Record r, Instant cutoff) {
+        if (r.getCreatedAt() == null) return false;
+        Instant created = r.getCreatedAt().toDate().toInstant();
+        return created.isBefore(cutoff);
+    }
+
+    private Mono<Record> deleteRecord(Record r) {
+        return storageService.deleteObjectByUrl(r.getUrl())
+                .onErrorResume(e -> {
+                    log.warn("Failed to delete file {}", r.getUrl(), e);
+                    return Mono.empty();
+                })
+                .then(repo.deleteById(r.getId()))
+                .thenReturn(r);
+    }
+}

--- a/backend/src/main/java/com/example/datalake/backend/service/RecordService.java
+++ b/backend/src/main/java/com/example/datalake/backend/service/RecordService.java
@@ -24,6 +24,10 @@ public class RecordService {
         return repo.findById(id);
     }
 
+    public Flux<Record> findByOwner(String owner) {
+        return repo.findByOwner(owner);
+    }
+
     /* ---------- CREATE (DTO → Entity) ---------- */
     public Mono<Record> create(RecordDto dto) {
         Record entity = toEntity(dto);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.cloud.gcp.project-id = blog-d45ae
 spring.jpa.hibernate.ddl-auto = update
 springdoc.api-docs.path = /v3/api-docs
 springdoc.swagger-ui.path = /swagger-ui.html
+
+# --- record cleanup configuration ----------------------------------
+record.cleanup.ttl-hours = 24
+record.cleanup.interval = 3600000


### PR DESCRIPTION
## Summary
- enable scheduling in the backend
- add `RecordCleanupScheduler` that removes records and their files 24h after creation

## Testing
- `./backend/mvnw test` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_685e22b6c5e08325a7ee9b0228ec18ec