### PR TITLE
Add description field and owner uniqueness in create

### DIFF
--- a/backend/src/main/java/com/example/datalake/backend/dto/RecordDto.java
+++ b/backend/src/main/java/com/example/datalake/backend/dto/RecordDto.java
@@ -30,4 +30,7 @@ public class RecordDto {
 
     @Schema(description = "Owner username", example = "alice")
     private String owner;
+
+    @Schema(description = "Optional description of the record")
+    private String description;
 }

--- a/backend/src/main/java/com/example/datalake/backend/model/Record.java
+++ b/backend/src/main/java/com/example/datalake/backend/model/Record.java
@@ -32,4 +32,6 @@ public class Record {
 
     @NotBlank(message = "owner must not be blank")
     private String owner;
+
+    private String description;
 }

--- a/backend/src/main/java/com/example/datalake/backend/service/RecordService.java
+++ b/backend/src/main/java/com/example/datalake/backend/service/RecordService.java
@@ -34,7 +34,9 @@ public class RecordService {
         if (entity.getCreatedAt() == null) {
             entity.setCreatedAt(Timestamp.now());
         }
-        return repo.save(entity);
+        return repo.findByOwner(entity.getOwner())
+                .flatMap(existing -> repo.deleteById(existing.getId()))
+                .then(repo.save(entity));
     }
 
     /* ---------- UPDATE ---------- */
@@ -57,6 +59,7 @@ public class RecordService {
                 : Timestamp.now());
         r.setUrl(dto.getUrl());
         r.setOwner(dto.getOwner());
+        r.setDescription(dto.getDescription());
         return r;
     }
 


### PR DESCRIPTION
## Summary
- add a `description` field to `Record` entity and DTO
- ensure `RecordService#create` deletes existing records for the owner before saving a new one

## Testing
- `mvn -q -pl backend -am test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5e89ff48325afbd4e64f1b72422