### PR TITLE
Fix tests with firebase mocks

### DIFF
--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import { signOut } from 'firebase/auth';
 import { auth } from './lib/firebaseClient';
+import logo from './logo.svg';
 
 function Home({ user }) {
   return (
     <div className="App">
-      {user.photoURL && (
-        <img src={user.photoURL} alt="Profile" style={{ borderRadius: '50%' }} />
-      )}
+      <img
+        src={user.photoURL || logo}
+        alt="Profile"
+        style={{ borderRadius: '50%', width: 96, height: 96 }}
+      />
       <h1>Welcome {user.displayName || user.email}</h1>
       <p>{user.email}</p>
       <button onClick={() => signOut(auth)}>Sign Out</button>

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,22 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock Firebase modules to avoid initialization errors in tests
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(() => ({})),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(() => ({})),
+}));
+
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(() => ({})),
+  onAuthStateChanged: jest.fn((_, cb) => cb(null)),
+  signOut: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+  GoogleAuthProvider: jest.fn(),
+  signInWithPopup: jest.fn(),
+}));


### PR DESCRIPTION
## Summary
- mock firebase modules during tests so initialization succeeds
- show placeholder avatar when profile photo missing

## Testing
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eafd7a03083259fb7565425867068