### PR TITLE
Improve home layout and fallback image

### DIFF
--- a/frontend/src/Home.css
+++ b/frontend/src/Home.css
@@ -12,20 +12,50 @@ body {
   max-width: 600px;
   margin: 2rem auto;
   padding: 2rem;
-  text-align: center;
   background: #fff;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .profile {
   border-radius: 50%;
   width: 96px;
   height: 96px;
+  object-fit: cover;
 }
 
-input[type='file'] {
-  margin: 1rem 0;
+.profile-details {
+  flex: 1;
+}
+
+.welcome {
+  margin: 0;
+}
+
+.email {
+  margin: 0;
+  color: #666;
+  word-break: break-all;
+}
+
+.description {
+  width: 100%;
+  min-height: 80px;
+  padding: 0.5rem;
+  resize: vertical;
+}
+
+.file-input {
+  margin-top: 0.5rem;
 }
 
 .upload-preview {

--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -49,17 +49,32 @@ function Home({ user }) {
 
   return (
     <div className="home-container">
-      <img src={user.photoURL || logo} alt="Profile" className="profile" />
-      <h1>Welcome {user.displayName || user.email}</h1>
-      <p>{user.email}</p>
+      <div className="profile-section">
+        <img
+          src={user.photoURL || logo}
+          alt="Profile"
+          className="profile"
+          referrerPolicy="no-referrer"
+          onError={(e) => {
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = logo;
+          }}
+        />
+        <div className="profile-details">
+          <h1 className="welcome">Welcome {user.displayName || user.email}</h1>
+          <p className="email">{user.email}</p>
+        </div>
+      </div>
 
       <textarea
+        className="description"
         placeholder="Description (optional)"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
       />
 
       <input
+        className="file-input"
         type="file"
         accept="image/*"
         capture="environment"


### PR DESCRIPTION
## Summary
- update home page layout for cleaner presentation
- add fallback logic so broken profile images fall back to the logo

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685f02efa9e08325b39733d21214392e