### PR TITLE
Add Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+*/target
+*/node_modules

--- a/README.md
+++ b/README.md
@@ -54,3 +54,20 @@ Set `REACT_APP_BACKEND_BASE_URL` to the URL of the Spring Boot backend. When run
 ```
 REACT_APP_BACKEND_BASE_URL=http://localhost:8080
 ```
+
+## Running with Docker
+
+Dockerfiles are provided for the backend and frontend. The easiest way to run the
+full stack is using Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The backend will be exposed on `http://localhost:8080` and the frontend on
+`http://localhost:3000`.
+
+If you need to provide a Firebase service account file, mount it into the backend
+container and set the `firebase.credentials-file` property via an environment
+variable or command line argument.
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM maven:3.9.7-eclipse-temurin-17 AS build
+WORKDIR /workspace
+COPY pom.xml ./
+COPY backend ./backend
+# Copy frontend pom only for Maven module structure
+COPY frontend/pom.xml ./frontend/pom.xml
+RUN mvn -pl backend -am -DskipTests package
+
+# Runtime stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /workspace/backend/target/backend-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=default
+    # option to mount firebase credentials if needed
+    volumes:
+      - ./backend:/workspace/backend
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build frontend assets
+FROM node:18 AS build
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend .
+RUN npm run build
+
+# Serve with nginx
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- create Dockerfiles for backend and frontend
- add docker-compose configuration
- document running with Docker
- ignore build artefacts in Docker context

## Testing
- `./mvnw -q test -Dspring.profiles.active=test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_685f078e5ce88325a910e6c85dbc8440