### PR TITLE
Fix userId field and allow iPhone uploads

### DIFF
--- a/frontend/src/Home.js
+++ b/frontend/src/Home.js
@@ -5,6 +5,8 @@ import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import logo from './logo.svg';
 import './Home.css';
 
+const isIPhone = /iPhone/i.test(navigator.userAgent);
+
 function Home({ user }) {
   const [uploading, setUploading] = useState(false);
   const [url, setUrl] = useState('');
@@ -33,6 +35,7 @@ function Home({ user }) {
             },
             body: JSON.stringify({
               url: downloadURL,
+              owner: user.uid,
               description,
             }),
           }
@@ -74,8 +77,8 @@ function Home({ user }) {
       <input
         className="file-input"
         type="file"
-        accept="image/*"
-        capture="environment"
+        accept="image/*,video/*"
+        capture={isIPhone ? undefined : 'environment'}
         onChange={handleFileChange}
       />
       {uploading && <p>Uploading...</p>}


### PR DESCRIPTION
## Summary
- include the logged in user's UID when posting new records
- detect iPhone devices so file input can access the photo library
- allow image or video uploads for Live Photos

## Testing
- `npm test` (frontend)
- `./mvnw -q test` *(fails: needs internet)*

------
https://chatgpt.com/codex/tasks/task_e_686c402a44648325a843a41d3a9d5988